### PR TITLE
Cater for internal experiments

### DIFF
--- a/src/helpers.php
+++ b/src/helpers.php
@@ -31,6 +31,10 @@ if (!function_exists('experiment_group')) {
             return 'test';
         }
 
+        if (mb_strstr($experiment, 'internal')) {
+            return 'internal';
+        }
+
         return 'control';
     }
 }


### PR DESCRIPTION
Provides a mechanism for us to manually set the cookie value to `internal` and set experiment config on the venture to behave as we want to test it