### PR TITLE
Remove renovate

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -1,5 +1,0 @@
-{
-  "$schema": "https://docs.renovatebot.com/renovate-schema.json",
-  "extends": ["local>RingierIMU/renovate-config"],
-  "reviewers": ["lucidlogic", "rklugman", "erhardt-ringiersa"]
-}


### PR DESCRIPTION
The repo needs to be private in order to gain most of the shared config benefits